### PR TITLE
Searchable flag on created date folders set to 0

### DIFF
--- a/modCategory/373019a8dab2f1e5a91048ae3f2fee7c/0/autofolders/autofolders.inc.php
+++ b/modCategory/373019a8dab2f1e5a91048ae3f2fee7c/0/autofolders/autofolders.inc.php
@@ -233,6 +233,7 @@ foreach ($folders as $i=>$f) {
 			
 		$newdoc->set('isfolder', '1');	
 		$newdoc->set('published', '1');
+		$newdoc->set('searchable', '1');
 		$newdoc->set('template', $new_page_template);
 		$newdoc->set('longtitle', $new_title);	
 		$newdoc->set('menutitle', $titles[$f]);	


### PR DESCRIPTION
When creating a new folder, the searchable flag is currently left as default 1 which means using a snippet like SimpleSearch will search the folders. This just forces the searchable flag to 0.

Could also make this a setting on the plugin options.
